### PR TITLE
Fix for dashboard errors - raspberrypi

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -25,6 +25,7 @@ class Session{
 	public $isp; // string
 	public $hosted; // bool
 	public $traffic;
+	public $city;
 	
 	function __construct($session) {
 		$this->id = checkInt($session[0]);

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -451,6 +451,9 @@ function getSessionsGeoData($sessionsRPC){
   $sessionData['newsessionsc'] = $newSessionsC;
   $sessionData['countrylist'] = $countryList;
 
+  // Ensure $arraySessions is defined and initialized
+  $arraySessions = $arraySessions ?? [];
+  
   // Removes all sessions that the node is not connected to anymore.
   foreach($arraySessions as $key => $session){
     if($session[6] == 0){


### PR DESCRIPTION
### Fixes warning and one deprection:

Warning: Undefined variable $arraySessions in /data/dashboard/src/Utility.php on line 455

Warning: foreach() argument must be of type array|object, null given in /data/dashboard/src/Utility.php on line 455

Deprecated: Creation of dynamic property App\Session::$city is deprecated in /data/dashboard/src/Utility.php on line 432